### PR TITLE
Give permissions for auto-commit

### DIFF
--- a/.github/workflows/autoupdate.yml
+++ b/.github/workflows/autoupdate.yml
@@ -6,6 +6,8 @@ on:
     inputs: {}
 
 jobs:
+  permissions:
+    contents: write
   update-commit:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/autoupdate.yml
+++ b/.github/workflows/autoupdate.yml
@@ -12,14 +12,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Git repository
-        uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+        uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.10'
       - name: Install dependencies
         run: pip install semver jinja2
       - name: Run autoupdate.py
         run: ./autoupdate.py
-      - uses: stefanzweifel/git-auto-commit-action@v4
+      - uses: stefanzweifel/git-auto-commit-action@8756aa072ef5b4a080af5dc8fef36c5d586e521d
         with:
             commit_message: "Auto-update package versions"


### PR DESCRIPTION
Our GITHUB_TOKEN permissions no longer include `contents: write` by default, so explicitly add it.