### PR TITLE
Fix lint error raised by homebrew tests

### DIFF
--- a/Formula.rb.tpl
+++ b/Formula.rb.tpl
@@ -16,7 +16,7 @@ class {{ name.capitalize() }}Cli{{ channel.capitalize() if channel != "release" 
         using: :nounzip
       sha256 "{{ artifacts['aarch64-apple-darwin']['sha256'] }}"
 
-      def install
+      define_method :install do
         bin.install "{{ artifacts['aarch64-apple-darwin']['file']  }}" => "{{ binary }}"
         install_completions
       end
@@ -25,7 +25,7 @@ class {{ name.capitalize() }}Cli{{ channel.capitalize() if channel != "release" 
         using: :nounzip
       sha256 "{{ artifacts['x86_64-apple-darwin']['sha256'] }}"
 
-      def install
+      define_method :install do
         bin.install "{{ artifacts['x86_64-apple-darwin']['file']  }}" => "{{ binary }}"
         install_completions
       end
@@ -40,7 +40,7 @@ class {{ name.capitalize() }}Cli{{ channel.capitalize() if channel != "release" 
         using: :nounzip
       sha256 "{{ artifacts["aarch64-unknown-linux-musl"]["sha256"] }}"
 
-      def install
+      define_method :install do
         bin.install "{{ artifacts['aarch64-unknown-linux-musl']['file']  }}" => "{{ binary }}"
         install_completions
       end
@@ -49,7 +49,7 @@ class {{ name.capitalize() }}Cli{{ channel.capitalize() if channel != "release" 
         using: :nounzip
       sha256 "{{ artifacts["x86_64-unknown-linux-musl"]["sha256"] }}"
 
-      def install
+      define_method :install do
         bin.install "{{ artifacts['x86_64-unknown-linux-musl']['file']  }}" => "{{ binary }}"
         install_completions
       end

--- a/Formula/edgedb-cli-nightly.rb
+++ b/Formula/edgedb-cli-nightly.rb
@@ -14,7 +14,7 @@ class EdgedbCliNightly < Formula
         using: :nounzip
       sha256 "f117e176b02c142680aa6c8d4920223de6911a039b3e3dee6dff4964abd817a1"
 
-      def install
+      define_method :install do
         bin.install "edgedb-cli-6.2.0-dev.1269+234034a" => "edgedb-nightly"
         install_completions
       end
@@ -23,7 +23,7 @@ class EdgedbCliNightly < Formula
         using: :nounzip
       sha256 "40ff250a8f5f719a8a3605e3ab8c5326d09fd02b229f486860f096505b5e64ac"
 
-      def install
+      define_method :install do
         bin.install "edgedb-cli-6.2.0-dev.1269+234034a" => "edgedb-nightly"
         install_completions
       end
@@ -38,7 +38,7 @@ class EdgedbCliNightly < Formula
         using: :nounzip
       sha256 "bf299d1e287a3cbdfd16dec106721a2199eb702db661044500b940bb635b4e69"
 
-      def install
+      define_method :install do
         bin.install "edgedb-cli-6.2.0-dev.1269+e373d52" => "edgedb-nightly"
         install_completions
       end
@@ -47,7 +47,7 @@ class EdgedbCliNightly < Formula
         using: :nounzip
       sha256 "a7d0790c7afc151d84fc54d5c2725b5f14fda903122c0c27d2e22651aa11e3cf"
 
-      def install
+      define_method :install do
         bin.install "edgedb-cli-6.2.0-dev.1269+b471b49" => "edgedb-nightly"
         install_completions
       end

--- a/Formula/edgedb-cli-testing.rb
+++ b/Formula/edgedb-cli-testing.rb
@@ -14,7 +14,7 @@ class EdgedbCliTesting < Formula
         using: :nounzip
       sha256 "529cc1d5f2ad4333962d250a06cc9950b9c3b5a05c35236114c15d10317da976"
 
-      def install
+      define_method :install do
         bin.install "edgedb-cli-4.0.0-alpha.1+ddfbe70" => "edgedb-testing"
         install_completions
       end
@@ -23,7 +23,7 @@ class EdgedbCliTesting < Formula
         using: :nounzip
       sha256 "bc579953feaf6a0855c27255726cfe0bc0e54cb289bd13ff2bbb926a3dc3561a"
 
-      def install
+      define_method :install do
         bin.install "edgedb-cli-4.0.0-alpha.1+285f84f" => "edgedb-testing"
         install_completions
       end
@@ -38,7 +38,7 @@ class EdgedbCliTesting < Formula
         using: :nounzip
       sha256 "5352e68940114f38e51f90a9c94577368a5f9614d85ee02dbee05b339fa33ae0"
 
-      def install
+      define_method :install do
         bin.install "edgedb-cli-4.0.0-alpha.1+51ec714" => "edgedb-testing"
         install_completions
       end
@@ -47,7 +47,7 @@ class EdgedbCliTesting < Formula
         using: :nounzip
       sha256 "23f1e6d1f982756cad8385dc404c09a167d5ccf8a39724826bb609ab98e09b9d"
 
-      def install
+      define_method :install do
         bin.install "edgedb-cli-4.0.0-alpha.1+dce7814" => "edgedb-testing"
         install_completions
       end

--- a/Formula/edgedb-cli.rb
+++ b/Formula/edgedb-cli.rb
@@ -14,7 +14,7 @@ class EdgedbCli < Formula
         using: :nounzip
       sha256 "02c7a0e45399710ecdd51e38b8647012f9dcd31c292f95b8cf5fe3119251c1d8"
 
-      def install
+      define_method :install do
         bin.install "edgedb-cli-6.1.2+02c2b9d" => "edgedb"
         install_completions
       end
@@ -23,7 +23,7 @@ class EdgedbCli < Formula
         using: :nounzip
       sha256 "9b5f795835e4eeba573283c9a7b41f7c91073c9d062e9d4789ef4568d54abefa"
 
-      def install
+      define_method :install do
         bin.install "edgedb-cli-6.1.2+02c2b9d" => "edgedb"
         install_completions
       end
@@ -38,7 +38,7 @@ class EdgedbCli < Formula
         using: :nounzip
       sha256 "4bfc7f15711698626faf3a3412489dfb9fb5958a560f7654ec8045b43e9c6048"
 
-      def install
+      define_method :install do
         bin.install "edgedb-cli-6.1.2+f4c653c" => "edgedb"
         install_completions
       end
@@ -47,7 +47,7 @@ class EdgedbCli < Formula
         using: :nounzip
       sha256 "3217ad2180772c9f6d39216ccd5ec4775f651d83e6804e652f3aa903042609e5"
 
-      def install
+      define_method :install do
         bin.install "edgedb-cli-6.1.2+ac96ce0" => "edgedb"
         install_completions
       end

--- a/Formula/gel-cli-nightly.rb
+++ b/Formula/gel-cli-nightly.rb
@@ -14,7 +14,7 @@ class GelCliNightly < Formula
         using: :nounzip
       sha256 "60329b10374702e456d94d0c430582b698fb9a97fe3207ff8ce6468ad5bfe178"
 
-      def install
+      define_method :install do
         bin.install "gel-cli-7.5.0-dev.1372+5ab407b" => "gel-nightly"
         install_completions
       end
@@ -23,7 +23,7 @@ class GelCliNightly < Formula
         using: :nounzip
       sha256 "bedb04cb5ddd132e16422722d66a7fd4eeed513353d556a27ae8ff0aea7455d1"
 
-      def install
+      define_method :install do
         bin.install "gel-cli-7.5.0-dev.1372+fab03e9" => "gel-nightly"
         install_completions
       end
@@ -38,7 +38,7 @@ class GelCliNightly < Formula
         using: :nounzip
       sha256 "f9da81a6cb184c9ffe421b491c3d18ed9d4f786bb0482ac3e783513a26c1f652"
 
-      def install
+      define_method :install do
         bin.install "gel-cli-7.5.0-dev.1372+b43a5e0" => "gel-nightly"
         install_completions
       end
@@ -47,7 +47,7 @@ class GelCliNightly < Formula
         using: :nounzip
       sha256 "51d4333193d3ea30526140bf9f63da9a331142c45d7e4d72f032343739e7d136"
 
-      def install
+      define_method :install do
         bin.install "gel-cli-7.5.0-dev.1372+0f423e6" => "gel-nightly"
         install_completions
       end

--- a/Formula/gel-cli-testing.rb
+++ b/Formula/gel-cli-testing.rb
@@ -14,7 +14,7 @@ class GelCliTesting < Formula
         using: :nounzip
       sha256 "455dada1aae521453ab21063cfe5b0908001c74611234515574e21b1aa565339"
 
-      def install
+      define_method :install do
         bin.install "gel-cli-7.1.0-alpha.1+a8d565b" => "gel-testing"
         install_completions
       end
@@ -23,7 +23,7 @@ class GelCliTesting < Formula
         using: :nounzip
       sha256 "78aa0255f3aad78c3250c24dcbe026423d7e6dc17c187a91214657da2400ac20"
 
-      def install
+      define_method :install do
         bin.install "gel-cli-7.1.0-alpha.1+a8d565b" => "gel-testing"
         install_completions
       end
@@ -38,7 +38,7 @@ class GelCliTesting < Formula
         using: :nounzip
       sha256 "be74eccd0da295dc9ec613cc3807a196e8921a260cb4b78b472a72ff04bfcc8a"
 
-      def install
+      define_method :install do
         bin.install "gel-cli-7.1.0-alpha.1+5f95e8a" => "gel-testing"
         install_completions
       end
@@ -47,7 +47,7 @@ class GelCliTesting < Formula
         using: :nounzip
       sha256 "d892af584470451c1e64d669a0e4288be0ba7c36a0d00d1d9dfbfa3db5d3f17c"
 
-      def install
+      define_method :install do
         bin.install "gel-cli-7.1.0-alpha.1+073c70b" => "gel-testing"
         install_completions
       end

--- a/Formula/gel-cli.rb
+++ b/Formula/gel-cli.rb
@@ -14,7 +14,7 @@ class GelCli < Formula
         using: :nounzip
       sha256 "49a6b3a7df750bfd3018ba004761a91d8aba9a4295b488a32d6f96414a3c186a"
 
-      def install
+      define_method :install do
         bin.install "gel-cli-7.4.0+bb0c441" => "gel"
         install_completions
       end
@@ -23,7 +23,7 @@ class GelCli < Formula
         using: :nounzip
       sha256 "07db80fd17d6f0ec3365fc339589350f591b4ab1a058eeba6dbc9aa0c6eff03c"
 
-      def install
+      define_method :install do
         bin.install "gel-cli-7.4.0+bb0c441" => "gel"
         install_completions
       end
@@ -38,7 +38,7 @@ class GelCli < Formula
         using: :nounzip
       sha256 "ed9dbb41efe7a89fe927bfbd2abff85a09addab783ead3cb1a3e3400236585ee"
 
-      def install
+      define_method :install do
         bin.install "gel-cli-7.4.0+6a31e0e" => "gel"
         install_completions
       end
@@ -47,7 +47,7 @@ class GelCli < Formula
         using: :nounzip
       sha256 "7f340a393481bec55295edff6f2cc0ee44c8b4bd7e6c92d1a21cbcad38b7fb7b"
 
-      def install
+      define_method :install do
         bin.install "gel-cli-7.4.0+dad3a5f" => "gel"
         install_completions
       end


### PR DESCRIPTION
Fix Homebrew linting error for Sorbet/BlockMethodDefinition. Defining methods with def inside blocks is incompatible with Sorbet type checking and violates Ruby best practices. Using define_method instead is the standard approach for dynamic method definition within block contexts and satisfies Homebrew's linting requirements.